### PR TITLE
Config webpack-dev-middleware for minimal console.log mess.

### DIFF
--- a/tools/srcServer.js
+++ b/tools/srcServer.js
@@ -11,7 +11,18 @@ const app = express();
 const compiler = webpack(config);
 
 app.use(require('webpack-dev-middleware')(compiler, {
-  noInfo: true,
+  // Config for minimal console.log mess.
+  noInfo: false,
+  quiet: false,
+  stats: {
+    assets: false,
+    colors: true,
+    version: false,
+    hash: false,
+    timings: false,
+    chunks: false,
+    chunkModules: false
+  },	
   publicPath: config.output.publicPath
 }));
 


### PR DESCRIPTION
Disable chunks. It's very annoying. More than 600 lines of nothing.

webpack built 7371f7d0d3df2023cdf1 in 6298ms
Hash: 7371f7d0d3df2023cdf1
Version: webpack 1.13.0
Time: 6298ms
                                 Asset     Size  Chunks       Chunk Names
  f4769f9bdb7466be65088239c12046d1.eot  20.1 kB
448c34a56d699c29117adc64c43affeb.woff2    18 kB
 fa2772327f55d8198301fdb8bcfc8158.woff  23.4 kB
  e18bbf611f2a2e43afc071aa2f4e1512.ttf  45.4 kB
  89889688147bd7575d6327160d64e760.svg   109 kB
                             bundle.js   4.1 MB       0       main
chunk    {0} bundle.js (main) 1.45 MB [rendered]
    [0] multi main 52 bytes {0} [built]
    [1] ./~/eventsource-polyfill/dist/browserify-eventsource.js 852 bytes {0} [built]
    [2] ./~/eventsource-polyfill/dist/eventsource.js 17.7 kB {0} [built]
    [3] (webpack)-hot-middleware/client.js?reload=true 4.18 kB {0} [built]
    ...
    [699] ./~/bootstrap/dist/fonts/glyphicons-halflings-regular.svg 82 bytes {0} [built]