### PR TITLE
Fix issue #14

### DIFF
--- a/src/api/mockAuthorApi.js
+++ b/src/api/mockAuthorApi.js
@@ -36,6 +36,7 @@ class AuthorApi {
   }
 
   static saveAuthor(author) {
+	author = Object.assign({}, author); // to avoid manipulating object passed in.
     return new Promise((resolve, reject) => {
       setTimeout(() => {
         // Simulate server-side validation
@@ -59,7 +60,7 @@ class AuthorApi {
           authors.push(author);
         }
 
-        resolve(Object.assign({}, author));
+        resolve(author);
       }, delay);
     });
   }


### PR DESCRIPTION
I added `author = Object.assign({}, author);` to the `saveAuthor` function on line 39 of `mockAuthorApi.js`. I also removed `Object.assign` from inside the `resolve` call on line 62. This fixed the issue I was having with mockAuthorApi.js setting a value for `author.id` in my "client-side" authorActions.js file directly and causing my code to always think I was doing an update even when I was doing a create.
